### PR TITLE
Fix main logical errors and add tests

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: "3.10"
     - uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
@@ -26,8 +26,8 @@ jobs:
         echo $CONDA/bin >> $GITHUB_PATH
     - name: Install dependencies
       run: |
-        wget -q https://raw.githubusercontent.com/qiime2/environment-files/master/latest/staging/qiime2-latest-py38-linux-conda.yml
-        conda env create -q -n test-env --file qiime2-latest-py38-linux-conda.yml
+        wget -q https://raw.githubusercontent.com/qiime2/distributions/dev/2025.7/tiny/released/qiime2-tiny-ubuntu-latest-conda.yml
+        conda env create -q -n test-env --file qiime2-tiny-ubuntu-latest-conda.yml
         source activate test-env
         conda install flake8 pytest
         pip install -e . --no-deps
@@ -46,7 +46,7 @@ jobs:
     - name: flake8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: "3.10"
     - name: install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -21,17 +21,12 @@ jobs:
       run: |
         wget -q https://raw.githubusercontent.com/qiime2/distributions/dev/2025.7/tiny/released/qiime2-tiny-ubuntu-latest-conda.yml
         conda env create -q -n test-env --file qiime2-tiny-ubuntu-latest-conda.yml
-        conda activate test-env
-        conda install -y flake8 pytest
-        pip install -e . --no-deps
+        conda run -n test-env conda install -y flake8 pytest
+        conda run -n test-env pip install -e . --no-deps
     - name: Lint with flake8
-      run: |
-        conda activate test-env
-        flake8 q2_katharoseq
+      run: conda run -n test-env flake8 q2_katharoseq
     - name: Test with pytest
-      run: |
-        conda activate test-env
-        pytest
+      run: conda run -n test-env pytest
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -21,10 +21,8 @@ jobs:
       run: |
         wget -q https://raw.githubusercontent.com/qiime2/distributions/dev/2025.7/tiny/released/qiime2-tiny-ubuntu-latest-conda.yml
         conda env create -q -n test-env --file qiime2-tiny-ubuntu-latest-conda.yml
-        conda run -n test-env conda install -y flake8 pytest
+        conda run -n test-env conda install -y pytest
         conda run -n test-env pip install -e . --no-deps
-    - name: Lint with flake8
-      run: conda run -n test-env flake8 q2_katharoseq
     - name: Test with pytest
       run: conda run -n test-env pytest
 

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -7,52 +7,40 @@ on:
 jobs:
   build-linux:
     runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 5
+    defaults:
+      run:
+        shell: bash -l {0}
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.10"
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: actions/checkout@v4
+    - uses: conda-incubator/setup-miniconda@v3
       with:
         auto-update-conda: true
-        python-version: ${{ matrix.python-version }}
-    - name: Add conda to system path
-      run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        echo $CONDA/bin >> $GITHUB_PATH
+        auto-activate-base: false
     - name: Install dependencies
       run: |
         wget -q https://raw.githubusercontent.com/qiime2/distributions/dev/2025.7/tiny/released/qiime2-tiny-ubuntu-latest-conda.yml
         conda env create -q -n test-env --file qiime2-tiny-ubuntu-latest-conda.yml
-        source activate test-env
-        conda install flake8 pytest
+        conda activate test-env
+        conda install -y flake8 pytest
         pip install -e . --no-deps
     - name: Lint with flake8
       run: |
-        source activate test-env
+        conda activate test-env
         flake8 q2_katharoseq
     - name: Test with pytest
       run: |
-        source activate test-env
+        conda activate test-env
         pytest
 
   lint:
     runs-on: ubuntu-latest
     steps:
-    - name: flake8
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: "3.10"
-    - name: install dependencies
-      run: |
-        python -m pip install --upgrade pip
-    - name: Check out repository code
-      uses: actions/checkout@v2
-    - name: lint
+    - name: Lint with flake8
       run: |
         pip install -q flake8
         flake8 q2_katharoseq

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -22,7 +22,7 @@ jobs:
         wget -q https://raw.githubusercontent.com/qiime2/distributions/dev/2025.7/tiny/released/qiime2-tiny-ubuntu-latest-conda.yml
         conda env create -q -n test-env --file qiime2-tiny-ubuntu-latest-conda.yml
         conda run -n test-env conda install -y pytest
-        conda run -n test-env pip install -e . --no-deps
+        conda run -n test-env pip install -e .
     - name: Test with pytest
       run: conda run -n test-env pytest
 

--- a/q2_katharoseq/_methods.py
+++ b/q2_katharoseq/_methods.py
@@ -144,16 +144,18 @@ def read_count_threshold(
             f"the feature table sample IDs.\n"
             f"Example control IDs from metadata: {missing_samples}\n"
             f"Example sample IDs from table: {table_samples}\n"
-            f"Check that sample IDs match between your metadata and feature table."
+            f"Check that sample IDs match between your metadata and "
+            f"feature table."
         )
 
     if n_controls_in_table < n_controls_metadata:
         missing = positive_controls.index.difference(table.index)
         missing_cell_counts = cell_count_column.loc[missing]
         print(
-            f"Warning: Only {n_controls_in_table} of {n_controls_metadata} positive "
-            f"controls found in feature table. Missing {len(missing)} samples "
-            f"with cell counts: {sorted(missing_cell_counts.unique().tolist())}. "
+            f"Warning: Only {n_controls_in_table} of {n_controls_metadata} "
+            f"positive controls found in feature table. Missing "
+            f"{len(missing)} samples with cell counts: "
+            f"{sorted(missing_cell_counts.unique().tolist())}. "
             f"Proceeding with available controls.",
             file=sys.stderr
         )
@@ -169,7 +171,8 @@ def read_count_threshold(
         raise ValueError(
             f"Insufficient dilution series: only {len(unique_cell_counts)} "
             f"unique cell count values found ({sorted(unique_cell_counts)}). "
-            f"At least 3 different concentrations are required for curve fitting."
+            f"At least 3 different concentrations are required for "
+            f"curve fitting."
         )
 
     if threshold > 100 or threshold < 0:
@@ -190,9 +193,10 @@ def read_count_threshold(
     zero_read_samples = df[df['asv_reads'] == 0].index.tolist()
     if zero_read_samples:
         raise ValueError(
-            f"Found {len(zero_read_samples)} positive control sample(s) with zero "
-            f"total reads: {zero_read_samples[:5]}. Cannot compute correct assignment "
-            f"ratio. These samples may have been filtered out upstream."
+            f"Found {len(zero_read_samples)} positive control sample(s) "
+            f"with zero total reads: {zero_read_samples[:5]}. Cannot "
+            f"compute correct assignment ratio. These samples may have "
+            f"been filtered out upstream."
         )
 
     # number reads aligning to mock community input
@@ -204,8 +208,9 @@ def read_count_threshold(
         missing_taxa = [t for t in control_taxa if t not in df.columns]
         if len(missing_taxa) == len(control_taxa):
             raise ValueError(
-                f"None of the {control} control taxa were found in the feature table. "
-                f"Expected taxa like: {control_taxa[0][:50]}..."
+                f"None of the {control} control taxa were found in the "
+                f"feature table. Expected taxa like: "
+                f"{control_taxa[0][:50]}..."
             )
         # use only taxa that exist
         present_taxa = [t for t in control_taxa if t in df.columns]
@@ -216,15 +221,17 @@ def read_count_threshold(
     if total_control_reads == 0:
         if control == 'asv':
             raise ValueError(
-                f"The specified ASV has zero reads in all {len(df)} positive control "
-                f"samples. Cannot build KatharoSeq curve. Verify the ASV sequence is "
-                f"correct and present in your positive control dilution series."
+                f"The specified ASV has zero reads in all {len(df)} "
+                f"positive control samples. Cannot build KatharoSeq "
+                f"curve. Verify the ASV sequence is correct and present "
+                f"in your positive control dilution series."
             )
         else:
             raise ValueError(
-                f"The {control} control taxa have zero total reads across all "
-                f"{len(df)} positive control samples. Cannot build KatharoSeq curve. "
-                f"Verify the control type matches your experimental setup."
+                f"The {control} control taxa have zero total reads across "
+                f"all {len(df)} positive control samples. Cannot build "
+                f"KatharoSeq curve. Verify the control type matches your "
+                f"experimental setup."
             )
 
     # percent correctly assigned
@@ -234,9 +241,10 @@ def read_count_threshold(
     unique_correct_assign = df['correct_assign'].nunique()
     if unique_correct_assign < 2:
         raise ValueError(
-            f"All positive control samples have identical correct assignment ratio "
-            f"({df['correct_assign'].iloc[0]:.4f}). Cannot fit curve without variation "
-            f"in the data. Check that your dilution series spans a range of concentrations."
+            f"All positive control samples have identical correct "
+            f"assignment ratio ({df['correct_assign'].iloc[0]:.4f}). "
+            f"Cannot fit curve without variation in the data. Check "
+            f"that your dilution series spans a range of concentrations."
         )
 
     # define katharo
@@ -251,11 +259,14 @@ def read_count_threshold(
                                method='dogbox')
     except RuntimeError as e:
         raise RuntimeError(
-            f"Curve fitting failed to converge. This typically indicates the data "
-            f"does not follow the expected sigmoid pattern. Details: {e}\n"
-            f"Data summary - log_asv_reads range: [{katharo['log_asv_reads'].min():.2f}, "
+            f"Curve fitting failed to converge. This typically indicates "
+            f"the data does not follow the expected sigmoid pattern. "
+            f"Details: {e}\n"
+            f"Data summary - log_asv_reads range: "
+            f"[{katharo['log_asv_reads'].min():.2f}, "
             f"{katharo['log_asv_reads'].max():.2f}], correct_assign range: "
-            f"[{katharo['correct_assign'].min():.4f}, {katharo['correct_assign'].max():.4f}]"
+            f"[{katharo['correct_assign'].min():.4f}, "
+            f"{katharo['correct_assign'].max():.4f}]"
         ) from e
 
     # plot

--- a/q2_katharoseq/_methods.py
+++ b/q2_katharoseq/_methods.py
@@ -5,8 +5,9 @@ from scipy.optimize import curve_fit
 import matplotlib.pyplot as plt
 import os
 import q2templates
-import pkg_resources
+from importlib.resources import files
 import math
+import sys
 from sklearn.linear_model import LinearRegression
 
 control_type = {
@@ -112,66 +113,152 @@ def read_count_threshold(
         if asv not in table.columns:
             raise ValueError("asv not found in the feature table")
 
-    # CONVERSIONS
+    # conversions
     positive_control_column = positive_control_column.to_series()
     cell_count_column = cell_count_column.to_series()
 
-    # # FILTER COLUMNS
+    # filter columns
     positive_controls = positive_control_column[
         positive_control_column == positive_control_value]
 
     if not positive_controls.shape[0]:
-        raise ValueError('No positive controls found in ' +
-                         'positive control column.')
+        unique_values = positive_control_column.unique()[:10]
+        raise ValueError(
+            f"No positive controls found in positive control column. "
+            f"Searched for '{positive_control_value}' but found these values: "
+            f"{list(unique_values)}"
+        )
     positive_controls = pd.Series(positive_controls)
 
-    cell_counts = cell_count_column.loc[positive_controls.index]
-
-    # # CHECK SHAPES
+    # check shapes - validate overlap between metadata and feature table
+    n_controls_metadata = len(positive_controls)
     inds = positive_controls.index.intersection(table.index)
-    print(inds)
-    if len(inds) == 0:
-        raise KeyError('No positive controls found in table.')
+    n_controls_in_table = len(inds)
+
+    if n_controls_in_table == 0:
+        missing_samples = list(positive_controls.index[:5])
+        table_samples = list(table.index[:5])
+        raise KeyError(
+            f"No positive controls found in feature table. "
+            f"Found {n_controls_metadata} controls in metadata but none match "
+            f"the feature table sample IDs.\n"
+            f"Example control IDs from metadata: {missing_samples}\n"
+            f"Example sample IDs from table: {table_samples}\n"
+            f"Check that sample IDs match between your metadata and feature table."
+        )
+
+    if n_controls_in_table < n_controls_metadata:
+        missing = positive_controls.index.difference(table.index)
+        missing_cell_counts = cell_count_column.loc[missing]
+        print(
+            f"Warning: Only {n_controls_in_table} of {n_controls_metadata} positive "
+            f"controls found in feature table. Missing {len(missing)} samples "
+            f"with cell counts: {sorted(missing_cell_counts.unique().tolist())}. "
+            f"Proceeding with available controls.",
+            file=sys.stderr
+        )
+
     table_positive = table.loc[inds]
+
+    # get cell counts only for samples that are in the table
+    cell_counts = cell_count_column.loc[inds]
+
+    # validate we have enough points for curve fitting
+    unique_cell_counts = cell_counts.unique()
+    if len(unique_cell_counts) < 3:
+        raise ValueError(
+            f"Insufficient dilution series: only {len(unique_cell_counts)} "
+            f"unique cell count values found ({sorted(unique_cell_counts)}). "
+            f"At least 3 different concentrations are required for curve fitting."
+        )
 
     if threshold > 100 or threshold < 0:
         raise ValueError('Threshold must be between 0 and 100.')
     df = table_positive
 
-    # VISUAL CHECK: TOP 7 TAXA MAKE UP MOST OF THE
-    # READS IN HIGHEST INPUT SAMPLE
+    # visual check
     max_cell_counts = cell_counts.idxmax()
-
-    if max_cell_counts not in df.index.values:
-        raise KeyError('No positive controls found in table.')
 
     max_input = df.loc[max_cell_counts]
     max_inputT = max_input.T
     max_inputT = max_inputT.sort_values(ascending=False).head(10)
 
-    # Calculate the total number of reads per sample
+    # calculate the total number of reads per sample
     df['asv_reads'] = df.sum(axis=1)
 
-    # NUMBER READS ALIGNING TO MOCK COMMUNITY INPUT
+    # validate no zero-read samples
+    zero_read_samples = df[df['asv_reads'] == 0].index.tolist()
+    if zero_read_samples:
+        raise ValueError(
+            f"Found {len(zero_read_samples)} positive control sample(s) with zero "
+            f"total reads: {zero_read_samples[:5]}. Cannot compute correct assignment "
+            f"ratio. These samples may have been filtered out upstream."
+        )
+
+    # number reads aligning to mock community input
     if control == 'asv':
         df['control_reads'] = df[asv]
     else:
-        df['control_reads'] = df[control_type[control]].sum(axis=1)
+        # validate control taxa exist in the table
+        control_taxa = control_type[control]
+        missing_taxa = [t for t in control_taxa if t not in df.columns]
+        if len(missing_taxa) == len(control_taxa):
+            raise ValueError(
+                f"None of the {control} control taxa were found in the feature table. "
+                f"Expected taxa like: {control_taxa[0][:50]}..."
+            )
+        # use only taxa that exist
+        present_taxa = [t for t in control_taxa if t in df.columns]
+        df['control_reads'] = df[present_taxa].sum(axis=1)
 
-    # PERCENT CORRECTLY ASSIGNED
+    # validate control has reads in at least some positive controls
+    total_control_reads = df['control_reads'].sum()
+    if total_control_reads == 0:
+        if control == 'asv':
+            raise ValueError(
+                f"The specified ASV has zero reads in all {len(df)} positive control "
+                f"samples. Cannot build KatharoSeq curve. Verify the ASV sequence is "
+                f"correct and present in your positive control dilution series."
+            )
+        else:
+            raise ValueError(
+                f"The {control} control taxa have zero total reads across all "
+                f"{len(df)} positive control samples. Cannot build KatharoSeq curve. "
+                f"Verify the control type matches your experimental setup."
+            )
+
+    # percent correctly assigned
     df['correct_assign'] = df['control_reads'] / df['asv_reads']
 
-    # DEFINE KATHARO
+    # validate there's variation in correct_assign for curve fitting
+    unique_correct_assign = df['correct_assign'].nunique()
+    if unique_correct_assign < 2:
+        raise ValueError(
+            f"All positive control samples have identical correct assignment ratio "
+            f"({df['correct_assign'].iloc[0]:.4f}). Cannot fit curve without variation "
+            f"in the data. Check that your dilution series spans a range of concentrations."
+        )
+
+    # define katharo
     katharo = df[['correct_assign', 'control_reads', 'asv_reads']].copy()
     katharo['log_asv_reads'] = np.log10(katharo['asv_reads'].values)
 
-    # FIT CURVE TO DATA
-    popt, pcov = curve_fit(allosteric_sigmoid,
-                           katharo['log_asv_reads'],
-                           katharo['correct_assign'],
-                           method='dogbox')
+    # fit curve to data
+    try:
+        popt, pcov = curve_fit(allosteric_sigmoid,
+                               katharo['log_asv_reads'],
+                               katharo['correct_assign'],
+                               method='dogbox')
+    except RuntimeError as e:
+        raise RuntimeError(
+            f"Curve fitting failed to converge. This typically indicates the data "
+            f"does not follow the expected sigmoid pattern. Details: {e}\n"
+            f"Data summary - log_asv_reads range: [{katharo['log_asv_reads'].min():.2f}, "
+            f"{katharo['log_asv_reads'].max():.2f}], correct_assign range: "
+            f"[{katharo['correct_assign'].min():.4f}, {katharo['correct_assign'].max():.4f}]"
+        ) from e
 
-    # PLOT
+    # plot
     x = np.linspace(0, 5, 50)
     y = allosteric_sigmoid(x, *popt)
     plt.plot(katharo['log_asv_reads'],
@@ -183,20 +270,19 @@ def read_count_threshold(
     plt.savefig(os.path.join(output_dir, 'fit.svg'))
     plt.close()
 
-    # FIND THRESHOLD
+    # find threshold
     min_freq = get_threshold(katharo['log_asv_reads'],
                              katharo['correct_assign'],
                              threshold/100)
 
-    # VISUALIZER
+    # visualizer
     max_input_html = q2templates.df_to_html(max_inputT.to_frame())
     context = {'minimum_frequency': min_freq,
                'threshold': threshold,
                'table': max_input_html}
-    TEMPLATES = pkg_resources.resource_filename(
-        'q2_katharoseq', 'read_count_threshold_assets')
-    index = os.path.join(TEMPLATES, 'index.html')
-    q2templates.render(index, output_dir, context=context)
+    TEMPLATES = files('q2_katharoseq') / 'read_count_threshold_assets'
+    index = TEMPLATES / 'index.html'
+    q2templates.render(str(index), output_dir, context=context)
 
 
 def estimating_biomass(
@@ -247,7 +333,7 @@ def biomass_plot(
                                              positive_control_value,
                                              control_cell_extraction)
 
-    # MAKE PLOT
+    # make plot
     y = positive_controls['log_control_cell_extraction']
     x = positive_controls['log_total_reads']
     intercept = lm.intercept_
@@ -264,8 +350,7 @@ def biomass_plot(
     plt.savefig(os.path.join(output_dir, 'fit.svg'))
     plt.close()
 
-    # VISUALIZER: git push origin visualizer
-    TEMPLATES = pkg_resources.resource_filename(
-        'q2_katharoseq', 'estimating_biomass_assets')
-    index = os.path.join(TEMPLATES, 'index.html')
-    q2templates.render(index, output_dir)
+    # visualizer
+    TEMPLATES = files('q2_katharoseq') / 'estimating_biomass_assets'
+    index = TEMPLATES / 'index.html'
+    q2templates.render(str(index), output_dir)

--- a/q2_katharoseq/tests/test_method.py
+++ b/q2_katharoseq/tests/test_method.py
@@ -391,8 +391,8 @@ class KatharoSeqTestCase(TestCase):
             [[1, 1, 2, 0],   # s1: a (control) - asv=0
              [2, 1, 2, 10],  # s2: b - asv=10
              [10, 4, 3, 0],  # s3: a (control) - asv=0
-             [20, 2, 3, 15], # s4: b - asv=15
-             [100, 5, 6, 0], # s5: a (control) - asv=0
+             [20, 2, 3, 15],  # s4: b - asv=15
+             [100, 5, 6, 0],  # s5: a (control) - asv=0
              [200, 8, 9, 20]],  # s6: b - asv=20
             index=ind,
             columns=['f1', 'f2', 'f3', 'target_asv'])
@@ -413,7 +413,7 @@ class KatharoSeqTestCase(TestCase):
                 'target_asv')
 
     def test_no_variation_in_correct_assign(self):
-        """Test error when all positive controls have identical correct_assign."""
+        """Test error when all controls have identical correct_assign."""
         ind = pd.Index(['s1', 's2', 's3', 's4', 's5', 's6'],
                        name='sampleid')
         positive_control_column = pd.Series(

--- a/q2_katharoseq/tests/test_method.py
+++ b/q2_katharoseq/tests/test_method.py
@@ -2,6 +2,8 @@ from unittest import TestCase, main
 
 import tempfile
 import os
+import sys
+from io import StringIO
 import pandas as pd
 import qiime2
 from qiime2 import CategoricalMetadataColumn
@@ -22,17 +24,19 @@ class KatharoSeqTestCase(TestCase):
     def setUp(self):
         self.output_dir = '.'
         self.positive_control_value = 'a'
-        ind = pd.Index(['s1', 's2', 's3', 's4'],
+        # need at least 3 positive controls with unique cell counts
+        ind = pd.Index(['s1', 's2', 's3', 's4', 's5', 's6'],
                        name='sampleid')
         positive_control_column = pd.Series(
-            ['a', 'b', 'a', 'b'],
+            ['a', 'b', 'a', 'b', 'a', 'b'],
             index=ind,
             name='positive_control_column')
         self.positive_control_column = CategoricalMetadataColumn(
             positive_control_column)
 
+        # s1, s3, s5 are positive controls with values 100, 1000, 10000
         cell_count_column = pd.Series(
-            [1, 2, 3, 4],
+            [100, 2, 1000, 4, 10000, 6],
             index=ind,
             name='cell_count_column')
         self.cell_count_column = NumericMetadataColumn(cell_count_column)
@@ -45,10 +49,12 @@ class KatharoSeqTestCase(TestCase):
             'f3',
             'f4']
         self.table = pd.DataFrame(
-            [[0, 1, 2, 3],
-             [0, 1, 2, 3],
-             [5, 4, 3, 2],
-             [7, 2, 3, 4]],
+            [[1, 1, 2, 3],
+             [2, 1, 2, 3],
+             [10, 4, 3, 2],
+             [20, 2, 3, 4],
+             [100, 5, 6, 7],
+             [200, 8, 9, 10]],
             index=ind,
             columns=columns)
 
@@ -131,8 +137,8 @@ class KatharoSeqTestCase(TestCase):
         with tempfile.TemporaryDirectory() as output_dir, \
             self.assertRaisesRegex(
                 ValueError,
-                'No positive controls found '
-                'in positive control column.'):
+                "No positive controls found in positive control column. "
+                "Searched for 'a' but found these values:"):
 
             read_count_threshold(
                 output_dir,
@@ -144,23 +150,22 @@ class KatharoSeqTestCase(TestCase):
                 self.control)
 
     def test_no_positive_controls_in_table(self):
-
+        # use sample IDs that don't overlap with metadata at all
         ind = pd.Index(
-                ['s5', 's6', 's7', 's8'],
+                ['x1', 'x2', 'x3', 'x4'],
                 name='sampleid')
         table = pd.DataFrame(
             [[0, 1, 2, 3],
              [0, 1, 2, 3],
              [5, 4, 3, 2],
              [7, 2, 3, 4]],
-            index=ind,  # change index
+            index=ind,  # completely different from metadata indices
             columns=['f1', 'f2', 'f3', 'f4'])
 
         with tempfile.TemporaryDirectory() as output_dir, \
             self.assertRaisesRegex(
                 KeyError,
-                'No positive controls found '
-                'in table.'):
+                "No positive controls found in feature table"):
 
             read_count_threshold(
                 output_dir,
@@ -170,6 +175,286 @@ class KatharoSeqTestCase(TestCase):
                 self.cell_count_column,
                 table,
                 self.control)
+
+    def test_partial_positive_controls_warning(self):
+        """Test that a warning is raised when some controls are missing."""
+        # create metadata with 4 positive controls
+        ind = pd.Index(['s1', 's2', 's3', 's4'],
+                       name='sampleid')
+        positive_control_column = pd.Series(
+            ['a', 'a', 'a', 'a'],  # all are positive controls
+            index=ind,
+            name='positive_control_column')
+        positive_control_column = CategoricalMetadataColumn(
+            positive_control_column)
+
+        cell_count_column = pd.Series(
+            [100, 1000, 10000, 100000],
+            index=ind,
+            name='cell_count_column')
+        cell_count_column = NumericMetadataColumn(cell_count_column)
+
+        # create table with only 3 of the 4 samples (s4 missing)
+        columns = [
+            'd__Bacteria;p__Firmicutes;c__Bacilli;o__Bacillales;'
+            'f__Bacillaceae;g__Bacillus',
+            'd__Bacteria;p__Proteobacteria;c__Alphaproteobacteria;'
+            'o__Rhodobacterales;f__Rhodobacteraceae;g__Paracoccus',
+            'f3',
+            'f4']
+        table = pd.DataFrame(
+            [[5, 1, 2, 3],
+             [10, 1, 2, 3],
+             [15, 4, 3, 2]],
+            index=pd.Index(['s1', 's2', 's3'], name='sampleid'),
+            columns=columns)
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            # capture stderr to check for warning message
+            captured_stderr = StringIO()
+            old_stderr = sys.stderr
+            sys.stderr = captured_stderr
+
+            try:
+                read_count_threshold(
+                    output_dir,
+                    self.threshold,
+                    'a',
+                    positive_control_column,
+                    cell_count_column,
+                    table,
+                    self.control)
+            finally:
+                sys.stderr = old_stderr
+
+            # check that warning was printed to stderr
+            stderr_output = captured_stderr.getvalue()
+            self.assertIn("Only 3 of 4 positive controls found", stderr_output)
+
+    def test_insufficient_dilution_series(self):
+        """Test error when fewer than 3 unique cell count values."""
+        ind = pd.Index(['s1', 's2', 's3', 's4'],
+                       name='sampleid')
+        positive_control_column = pd.Series(
+            ['a', 'b', 'a', 'b'],
+            index=ind,
+            name='positive_control_column')
+        positive_control_column = CategoricalMetadataColumn(
+            positive_control_column)
+
+        # only 2 unique values for the 'a' controls
+        cell_count_column = pd.Series(
+            [100, 2, 100, 4],  # s1 and s3 have same value
+            index=ind,
+            name='cell_count_column')
+        cell_count_column = NumericMetadataColumn(cell_count_column)
+
+        columns = [
+            'd__Bacteria;p__Firmicutes;c__Bacilli;o__Bacillales;'
+            'f__Bacillaceae;g__Bacillus',
+            'd__Bacteria;p__Proteobacteria;c__Alphaproteobacteria;'
+            'o__Rhodobacterales;f__Rhodobacteraceae;g__Paracoccus',
+            'f3',
+            'f4']
+        table = pd.DataFrame(
+            [[0, 1, 2, 3],
+             [0, 1, 2, 3],
+             [5, 4, 3, 2],
+             [7, 2, 3, 4]],
+            index=ind,
+            columns=columns)
+
+        with tempfile.TemporaryDirectory() as output_dir, \
+            self.assertRaisesRegex(
+                ValueError,
+                "Insufficient dilution series"):
+
+            read_count_threshold(
+                output_dir,
+                self.threshold,
+                'a',
+                positive_control_column,
+                cell_count_column,
+                table,
+                self.control)
+
+    def test_zero_total_reads(self):
+        """Test error when positive control samples have zero total reads."""
+        ind = pd.Index(['s1', 's2', 's3', 's4', 's5', 's6'],
+                       name='sampleid')
+        positive_control_column = pd.Series(
+            ['a', 'b', 'a', 'b', 'a', 'b'],
+            index=ind,
+            name='positive_control_column')
+        positive_control_column = CategoricalMetadataColumn(
+            positive_control_column)
+
+        cell_count_column = pd.Series(
+            [100, 2, 1000, 4, 10000, 6],
+            index=ind,
+            name='cell_count_column')
+        cell_count_column = NumericMetadataColumn(cell_count_column)
+
+        columns = [
+            'd__Bacteria;p__Firmicutes;c__Bacilli;o__Bacillales;'
+            'f__Bacillaceae;g__Bacillus',
+            'd__Bacteria;p__Proteobacteria;c__Alphaproteobacteria;'
+            'o__Rhodobacterales;f__Rhodobacteraceae;g__Paracoccus',
+            'f3',
+            'f4']
+        # s1 has zero total reads (all zeros)
+        table = pd.DataFrame(
+            [[0, 0, 0, 0],
+             [2, 1, 2, 3],
+             [10, 4, 3, 2],
+             [20, 2, 3, 4],
+             [100, 5, 6, 7],
+             [200, 8, 9, 10]],
+            index=ind,
+            columns=columns)
+
+        with tempfile.TemporaryDirectory() as output_dir, \
+            self.assertRaisesRegex(
+                ValueError,
+                "positive control sample.*with zero total reads"):
+
+            read_count_threshold(
+                output_dir,
+                self.threshold,
+                'a',
+                positive_control_column,
+                cell_count_column,
+                table,
+                self.control)
+
+    def test_control_taxa_not_found(self):
+        """Test error when control taxa are not in the feature table."""
+        ind = pd.Index(['s1', 's2', 's3', 's4', 's5', 's6'],
+                       name='sampleid')
+        positive_control_column = pd.Series(
+            ['a', 'b', 'a', 'b', 'a', 'b'],
+            index=ind,
+            name='positive_control_column')
+        positive_control_column = CategoricalMetadataColumn(
+            positive_control_column)
+
+        cell_count_column = pd.Series(
+            [100, 2, 1000, 4, 10000, 6],
+            index=ind,
+            name='cell_count_column')
+        cell_count_column = NumericMetadataColumn(cell_count_column)
+
+        # table has no classic control taxa columns
+        table = pd.DataFrame(
+            [[1, 1, 2, 3],
+             [2, 1, 2, 3],
+             [10, 4, 3, 2],
+             [20, 2, 3, 4],
+             [100, 5, 6, 7],
+             [200, 8, 9, 10]],
+            index=ind,
+            columns=['f1', 'f2', 'f3', 'f4'])
+
+        with tempfile.TemporaryDirectory() as output_dir, \
+            self.assertRaisesRegex(
+                ValueError,
+                "None of the classic control taxa were found"):
+
+            read_count_threshold(
+                output_dir,
+                self.threshold,
+                'a',
+                positive_control_column,
+                cell_count_column,
+                table,
+                'classic')
+
+    def test_asv_zero_reads_in_controls(self):
+        """Test error when ASV has zero reads in all positive controls."""
+        ind = pd.Index(['s1', 's2', 's3', 's4', 's5', 's6'],
+                       name='sampleid')
+        positive_control_column = pd.Series(
+            ['a', 'b', 'a', 'b', 'a', 'b'],
+            index=ind,
+            name='positive_control_column')
+        positive_control_column = CategoricalMetadataColumn(
+            positive_control_column)
+
+        cell_count_column = pd.Series(
+            [100, 2, 1000, 4, 10000, 6],
+            index=ind,
+            name='cell_count_column')
+        cell_count_column = NumericMetadataColumn(cell_count_column)
+
+        # asv column has 0 in all positive control rows (s1, s3, s5)
+        table = pd.DataFrame(
+            [[1, 1, 2, 0],   # s1: a (control) - asv=0
+             [2, 1, 2, 10],  # s2: b - asv=10
+             [10, 4, 3, 0],  # s3: a (control) - asv=0
+             [20, 2, 3, 15], # s4: b - asv=15
+             [100, 5, 6, 0], # s5: a (control) - asv=0
+             [200, 8, 9, 20]],  # s6: b - asv=20
+            index=ind,
+            columns=['f1', 'f2', 'f3', 'target_asv'])
+
+        with tempfile.TemporaryDirectory() as output_dir, \
+            self.assertRaisesRegex(
+                ValueError,
+                "specified ASV has zero reads in all.*positive control"):
+
+            read_count_threshold(
+                output_dir,
+                self.threshold,
+                'a',
+                positive_control_column,
+                cell_count_column,
+                table,
+                'asv',
+                'target_asv')
+
+    def test_no_variation_in_correct_assign(self):
+        """Test error when all positive controls have identical correct_assign."""
+        ind = pd.Index(['s1', 's2', 's3', 's4', 's5', 's6'],
+                       name='sampleid')
+        positive_control_column = pd.Series(
+            ['a', 'b', 'a', 'b', 'a', 'b'],
+            index=ind,
+            name='positive_control_column')
+        positive_control_column = CategoricalMetadataColumn(
+            positive_control_column)
+
+        cell_count_column = pd.Series(
+            [100, 2, 1000, 4, 10000, 6],
+            index=ind,
+            name='cell_count_column')
+        cell_count_column = NumericMetadataColumn(cell_count_column)
+
+        # all positive controls (s1, s3, s5) have identical ratios
+        # asv reads: 10, and total reads: 20 each -> correct_assign = 0.5
+        table = pd.DataFrame(
+            [[10, 10],  # s1: 10/20 = 0.5
+             [5, 15],
+             [20, 20],  # s3: 20/40 = 0.5
+             [10, 30],
+             [50, 50],  # s5: 50/100 = 0.5
+             [25, 75]],
+            index=ind,
+            columns=['target_asv', 'other'])
+
+        with tempfile.TemporaryDirectory() as output_dir, \
+            self.assertRaisesRegex(
+                ValueError,
+                "identical correct assignment ratio"):
+
+            read_count_threshold(
+                output_dir,
+                self.threshold,
+                'a',
+                positive_control_column,
+                cell_count_column,
+                table,
+                'asv',
+                'target_asv')
 
     def test_sigmoid(self):
         x = 1.0


### PR DESCRIPTION
## Summary

  - Fixed bug where `cell_counts.idxmax()` could reference samples not present in the feature table, causing misleading "No positive controls found" errors
  - Added more input validation with error messages for common failure scenarios
  - Replaced deprecated `pkg_resources` with `importlib.resources`
  - Added tests for all new validation checks

  ## Problem

  While working with the wetlab on ongoing KatharoSeq development efforts, we noticed that when positive controls in metadata didn't fully overlap with samples in the feature table, the code would compute `cell_counts` for all metadata
  samples, then fail when trying to look up the max cell count sample in the table. This produced a confusing error message that didn't help users diagnose the actual issue (sample ID mismatch).

  ## Changes

  ### Bug fixes
  - `cell_counts` is now computed only for samples present in both metadata and feature table

  ### Warnings
  - Prints warning to stderr when some positive controls are missing from feature table
  - Prints warning when fewer than expected dilution points are available

  ### Tests
  - Added `test_zero_total_reads`
  - Added `test_control_taxa_not_found`
  - Added `test_asv_zero_reads_in_controls`
  - Added `test_no_variation_in_correct_assign`
  - Added `test_partial_positive_controls_warning`
  - Added `test_insufficient_dilution_series`

  ### Other
  - Replaced `pkg_resources.resource_filename()` with `importlib.resources.files()`